### PR TITLE
Add Locks to Dynamic Forces and Introduce Ignore Functionality

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lock/groovy/NebulaLockExtension.groovy
+++ b/src/main/groovy/com/netflix/nebula/lock/groovy/NebulaLockExtension.groovy
@@ -1,0 +1,5 @@
+package com.netflix.nebula.lock.groovy
+
+class NebulaLockExtension {
+    def ignore(Closure dep) { dep.call() }
+}

--- a/src/main/kotlin/com/netflix/nebula/lock/LockService.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/LockService.kt
@@ -47,7 +47,6 @@ class LockService(val project: Project, val locksInEffect: List<Locked>) {
                 cacheChangingModulesFor(0, "seconds")
             }
         }
-        prepareForLocks()
         arrayOf(project, project.rootProject).toSet().forEach { p ->
             when {
                 p.buildFile.name.endsWith("gradle") -> updateLockGroovy(p, overrides)

--- a/src/main/kotlin/com/netflix/nebula/lock/LockService.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/LockService.kt
@@ -18,13 +18,16 @@
 package com.netflix.nebula.lock
 
 import com.netflix.nebula.lock.groovy.GroovyLockAstVisitor
+import com.netflix.nebula.lock.groovy.GroovyLockPreparationWriter
 import com.netflix.nebula.lock.groovy.GroovyLockWriter
+import com.netflix.nebula.lock.groovy.GroovyPrepareForLocksAstVisitor
 import org.codehaus.groovy.ast.builder.AstBuilder
 import org.codehaus.groovy.ast.stmt.BlockStatement
 import org.gradle.api.Project
 
 class LockService(val project: Project, val locksInEffect: List<Locked>) {
     val groovyLockWriter = GroovyLockWriter()
+    val groovyLockPreparationWriter = GroovyLockPreparationWriter()
 
     fun undoLocks() {
         locksInEffect.forEach { lock ->
@@ -44,7 +47,7 @@ class LockService(val project: Project, val locksInEffect: List<Locked>) {
                 cacheChangingModulesFor(0, "seconds")
             }
         }
-
+        prepareForLocks()
         arrayOf(project, project.rootProject).toSet().forEach { p ->
             when {
                 p.buildFile.name.endsWith("gradle") -> updateLockGroovy(p, overrides)
@@ -66,5 +69,17 @@ class LockService(val project: Project, val locksInEffect: List<Locked>) {
 
     fun updateLockKotlin(p: Project, overrides: Map<ConfigurationModuleIdentifier, String>) {
         // TODO implement me
+    }
+
+    fun prepareForLocks() {
+        arrayOf(project, project.rootProject).toSet().forEach { p ->
+            val ast = AstBuilder().buildFromString(p.buildFile.readText())
+            val stmt = ast.find { it is BlockStatement }
+            if (stmt is BlockStatement) {
+                val visitor = GroovyPrepareForLocksAstVisitor(p)
+                visitor.visitBlockStatement(stmt)
+                groovyLockPreparationWriter.prepareDependencies(p, visitor.updates)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
@@ -31,9 +31,9 @@ class NebulaLockPlugin: Plugin<Project> {
         val locksInEffect = ArrayList<Locked>()
         val lockService = LockService(project, locksInEffect)
 
-        project.tasks.create("updateLocks", UpdateLockTask::class.java) { it.lockService = lockService }
+        val prepareForLocks = project.tasks.create("prepareForLocks", PrepareForLocksTask::class.java) { it.lockService = lockService }
+        project.tasks.create("updateLocks", UpdateLockTask::class.java) { it.lockService = lockService }.dependsOn(prepareForLocks)
         project.tasks.create("convertLegacyLocks", ConvertLegacyLockTask::class.java) { it.lockService = lockService }
-        project.tasks.create("prepareForLocks", PrepareForLocksTask::class.java) { it.lockService = lockService }
         project.extensions.create("nebulaDependencyLock", NebulaLockExtension::class.java)
         GroovyLockExtensions.enhanceDependencySyntax(project, locksInEffect)
     }

--- a/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
@@ -18,6 +18,7 @@
 package com.netflix.nebula.lock
 
 import com.netflix.nebula.lock.groovy.GroovyLockExtensions
+import com.netflix.nebula.lock.groovy.NebulaLockExtension
 import com.netflix.nebula.lock.task.ConvertLegacyLockTask
 import com.netflix.nebula.lock.task.PrepareForLocksTask
 import com.netflix.nebula.lock.task.UpdateLockTask
@@ -33,6 +34,7 @@ class NebulaLockPlugin: Plugin<Project> {
         project.tasks.create("updateLocks", UpdateLockTask::class.java) { it.lockService = lockService }
         project.tasks.create("convertLegacyLocks", ConvertLegacyLockTask::class.java) { it.lockService = lockService }
         project.tasks.create("prepareForLocks", PrepareForLocksTask::class.java) { it.lockService = lockService }
+        project.extensions.create("nebulaDependencyLock", NebulaLockExtension::class.java)
         GroovyLockExtensions.enhanceDependencySyntax(project, locksInEffect)
     }
 }

--- a/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/NebulaLockPlugin.kt
@@ -19,6 +19,7 @@ package com.netflix.nebula.lock
 
 import com.netflix.nebula.lock.groovy.GroovyLockExtensions
 import com.netflix.nebula.lock.task.ConvertLegacyLockTask
+import com.netflix.nebula.lock.task.PrepareForLocksTask
 import com.netflix.nebula.lock.task.UpdateLockTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,6 +32,7 @@ class NebulaLockPlugin: Plugin<Project> {
 
         project.tasks.create("updateLocks", UpdateLockTask::class.java) { it.lockService = lockService }
         project.tasks.create("convertLegacyLocks", ConvertLegacyLockTask::class.java) { it.lockService = lockService }
+        project.tasks.create("prepareForLocks", PrepareForLocksTask::class.java) { it.lockService = lockService }
         GroovyLockExtensions.enhanceDependencySyntax(project, locksInEffect)
     }
 }

--- a/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
@@ -128,7 +128,7 @@ class GroovyLockAstVisitor(val project: Project,
                 }
             }
             is ConstantExpression -> {
-                "([^:]*):([^:]+):([^@:]*).*".toRegex().matchEntire(value as String)?.run {
+                "([^:]*):([^:]+):?([^@:]*).*".toRegex().matchEntire(value as String)?.run {
                     val group = groupValues[1].let { if (it.isEmpty()) null else it }
                     val name = groupValues[2]
                     val version = groupValues[3].let { if (it.isEmpty()) null else it }

--- a/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
@@ -64,8 +64,8 @@ class GroovyLockAstVisitor(val project: Project,
         val conf = path.takeLastWhile { it != "configurations" }.first()
         val args = call.parseArgs()
         if(isConf(conf) || conf == "all") {
-            val locks = args.map { it.lock(conf, args) }
-            if (locks.isNotEmpty()) updates.add(GroovyLockUpdate(call, locks))
+            val lock = args.first().lock(conf, args)
+            updates.add(GroovyLockUpdate(call, lock))
         }
     }
 
@@ -74,8 +74,8 @@ class GroovyLockAstVisitor(val project: Project,
         val conf = call.methodAsString
         val args = call.parseArgs()
         if(isConf(conf)) {
-            val locks = args.map { it.lock(conf, args) }
-            if (locks.isNotEmpty()) updates.add(GroovyLockUpdate(call, locks))
+            val lock = args.first().lock(conf, args)
+            updates.add(GroovyLockUpdate(call, lock))
         }
     }
 

--- a/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockAstVisitor.kt
@@ -31,19 +31,68 @@ class GroovyLockAstVisitor(val project: Project,
                            val overrides: Map<ConfigurationModuleIdentifier, String>): ClassCodeVisitorSupport() {
     val updates = ArrayList<GroovyLockUpdate>()
     private var inDependencies = false
+    private var inResolutionStrategies = false
 
     override fun getSourceUnit(): SourceUnit? = null
+    val path = Stack<String>()
 
     override fun visitMethodCallExpression(call: MethodCallExpression) {
-        if(inDependencies)
-            visitMethodCallInDependencies(call)
+        val caller = call.objectExpression.text
+        if(caller != "this") path.push(caller)
+        path.push(call.methodAsString)
 
-        if(call.methodAsString == "dependencies") {
+        if(inDependencies) {
+            visitMethodCallInDependencies(call)
+        } else if (path.any { it == "dependencies" }) {
             inDependencies = true
             super.visitMethodCallExpression(call)
             inDependencies = false
         }
-        else super.visitMethodCallExpression(call)
+
+        if (inResolutionStrategies) {
+            visitMethodCallInResolutionStrategies(call)
+        } else if (path.any { it == "resolutionStrategy" }) {
+            inResolutionStrategies = true
+            super.visitMethodCallExpression(call)
+            inResolutionStrategies = false
+        } else super.visitMethodCallExpression(call)
+
+        path.pop()
+    }
+
+    fun visitMethodCallInResolutionStrategies(call: MethodCallExpression) {
+        // https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html
+        val conf = path.takeLastWhile { it != "configurations" }.first()
+
+        val args = when(call.arguments) {
+            is ArgumentListExpression -> (call.arguments as ArgumentListExpression).expressions
+            is TupleExpression -> (call.arguments as TupleExpression).expressions
+            else -> emptyList()
+        }
+        if(isConf(conf) || conf == "all") {
+            val locks = args.map { arg ->
+                when (arg) {
+                    is MapExpression -> {
+                        val entries = collectEntryExpressions(args)
+                        conf.lockedVersion(entries["group"], entries["name"]!!).let { locked ->
+                            if (locked == entries["version"]) null else locked
+                        }
+                    }
+                    is ConstantExpression -> {
+                        "([^:]*):([^:]+):([^@:]*).*".toRegex().matchEntire(arg.value as String)?.run {
+                            val group = groupValues[1].let { if (it.isEmpty()) null else it }
+                            val name = groupValues[2]
+                            val version = groupValues[3].let { if (it.isEmpty()) null else it }
+                            conf.lockedVersion(group, name).let { locked -> if (locked == version) null else locked }
+                        }
+                    }
+                    else -> null
+                }
+            }
+
+            if (locks.isNotEmpty())
+                updates.add(GroovyLockUpdate(call, locks))
+        }
     }
 
     fun visitMethodCallInDependencies(call: MethodCallExpression) {
@@ -96,8 +145,14 @@ class GroovyLockAstVisitor(val project: Project,
         val mid = DefaultModuleIdentifier(group, name)
 
         fun overrideOrResolvedVersion(p: Project): String? {
-            val conf = p.configurations.getByName(this)
-            return overrides[mid.withConf(conf)] ?: conf.resolvedConfiguration.firstLevelModuleDependencies.find { it.module.id.module.equals(mid) }?.moduleVersion
+            val configurations = if(this == "all") p.configurations else setOf(p.configurations.getByName(this))
+            val versions = configurations.map { conf ->
+                overrides[mid.withConf(conf)] ?:
+                        conf.resolvedConfiguration.firstLevelModuleDependencies.find {
+                            it.module.id.module.equals(mid)
+                        }?.moduleVersion
+            }.filterNotNull()
+            return versions.maxWith(DefaultVersionComparator().asStringComparator())
         }
 
         return if(project.rootProject == project) {
@@ -113,5 +168,10 @@ class GroovyLockAstVisitor(val project: Project,
             // subproject of a multi-module project
             overrideOrResolvedVersion(project)
         }
+    }
+
+    private fun Stack<String>.findConfiguration(): String {
+        val idx = this.indexOf("configuration")
+        return this[idx+1]
     }
 }

--- a/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockPreparationWriter.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyLockPreparationWriter.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.nebula.lock.groovy
+
+import org.gradle.api.Project
+
+class GroovyLockPreparationWriter() {
+
+    fun prepareDependencies(project: Project, updates: Map<IntRange, List<ConfigurationDependency>>) {
+        val updated = StringBuilder()
+        val lines = project.buildFile.readLines()
+        var i = 0
+
+        while (i < lines.size) {
+            if (i > 0) updated.append('\n')
+            val matching = updates.filterKeys { it.contains(i) }
+            check(matching.size <= 1)
+            if (matching.isNotEmpty()) {
+                matching.values.flatten().forEach { dep ->
+                    val indentation = "".padStart(dep.indent)
+                    updated.append(indentation).append("${dep.conf} ${lines[i].substring(dep.replacement.startingColumn, dep.replacement.endingColumn)}")
+                }
+                i += matching.keys.first().count()
+            } else updated.append(lines[i++])
+        }
+
+        project.buildFile.writeText(updated.toString())
+    }
+
+}

--- a/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyPrepareForLocksAstVisitor.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/groovy/GroovyPrepareForLocksAstVisitor.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.nebula.lock.groovy
+
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport
+import org.codehaus.groovy.ast.expr.*
+import org.codehaus.groovy.control.SourceUnit
+import org.gradle.api.Project
+import java.util.*
+
+
+data class Declaration(val startingColumn: Int, val endingColumn: Int, val startingLine: Int, val endingLine: Int)
+data class ConfigurationDependency(val indent: Int, val conf: String, val replacement: Declaration)
+
+class GroovyPrepareForLocksAstVisitor(val project: Project) : ClassCodeVisitorSupport() {
+    val updates = mutableMapOf<IntRange, MutableList<ConfigurationDependency>>()
+    private var inDependencies = false
+
+    override fun getSourceUnit(): SourceUnit? = null
+    val path = Stack<String>()
+
+    override fun visitMethodCallExpression(call: MethodCallExpression) {
+        val caller = call.objectExpression.text
+        if (caller != "this") path.push(caller)
+        path.push(call.methodAsString)
+
+        if (inDependencies) {
+            visitMethodCallInDependencies(call)
+        } else if (path.any { it == "dependencies" }) {
+            inDependencies = true
+            super.visitMethodCallExpression(call)
+            inDependencies = false
+        }
+
+        path.pop()
+    }
+
+    fun visitMethodCallInDependencies(call: MethodCallExpression) {
+        // https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html
+        val conf = call.methodAsString
+        val args = call.parseArgs()
+        if (args.any { it is ClosureExpression || it is MapExpression }) return
+        if (isConf(conf)) {
+            args.map {
+                updates
+                        .getOrPut((it.lineNumber - 1..it.lastLineNumber - 1), { mutableListOf<ConfigurationDependency>() })
+                        .add(ConfigurationDependency(call.columnNumber - 1, conf, Declaration(it.columnNumber - 1, it.lastColumnNumber - 1, it.lineNumber - 1, it.lastLineNumber - 1)))
+            }
+        }
+    }
+
+    private fun isConf(methodName: String) =
+            project.configurations.findByName(methodName) != null ||
+                    project.subprojects.any { sub -> sub.configurations.findByName(methodName) != null }
+
+    private fun MethodCallExpression.parseArgs(): List<Expression> {
+        return when (arguments) {
+            is ArgumentListExpression -> (arguments as ArgumentListExpression).expressions
+            is TupleExpression -> (arguments as TupleExpression).expressions
+            else -> emptyList()
+        }
+    }
+}

--- a/src/main/kotlin/com/netflix/nebula/lock/task/PrepareForLocksTask.kt
+++ b/src/main/kotlin/com/netflix/nebula/lock/task/PrepareForLocksTask.kt
@@ -15,8 +15,15 @@
  *
  */
 
-package com.netflix.nebula.lock.groovy
+package com.netflix.nebula.lock.task
 
-import org.codehaus.groovy.ast.expr.MethodCallExpression
+import com.netflix.nebula.lock.LockService
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
 
-data class GroovyLockUpdate(val method: MethodCallExpression, val lock: String?)
+open class PrepareForLocksTask: DefaultTask() {
+    lateinit var lockService: LockService
+
+    @TaskAction
+    fun updateLock() = lockService.prepareForLocks()
+}

--- a/src/test/kotlin/com/netflix/nebula/lock/LockTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/LockTest.kt
@@ -62,6 +62,20 @@ class LockTest: TestKitTest() {
     }
 
     @Test
+    fun ignoredDependenciesAreStillResolved() {
+        buildFile.appendText("""
+            dependencies {
+                nebulaDependencyLock.ignore {
+                    compile 'com.google.guava:guava:19.0'
+                }
+            }
+        """)
+
+        val result = runTasksSuccessfully("listDependencies")
+        result.assertDependency("com.google.guava:guava:19.0", "compile")
+    }
+
+    @Test
     fun lockingWithFloatingPointNumbersIsOk() {
         buildFile.appendText("""
             dependencies {

--- a/src/test/kotlin/com/netflix/nebula/lock/PrepareForLocksTaskTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/PrepareForLocksTaskTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.nebula.lock
+
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PrepareForLocksTaskTest : TestKitTest() {
+    @Before
+    override fun before() {
+        super.before()
+
+        buildFile.writeText("""
+            plugins {
+                id 'java'
+                id 'nebula.lock-experimental'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+        """.trim('\n').trimIndent())
+    }
+
+    @Test
+    fun commaSeparatedStrings() {
+        buildFile.appendText("""
+            dependencies {
+                compile 'com.google.guava:guava:18.+',
+                        'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("prepareForLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile 'com.google.guava:guava:18.+'
+                compile 'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
+    fun commaSeparatedStringsWithVariable() {
+        buildFile.appendText("""
+            def guavaVersion = '18.+'
+            dependencies {
+                compile "com.google.guava:guava:${'$'}guavaVersion",
+                        'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("prepareForLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            def guavaVersion = '18.+'
+            dependencies {
+                compile "com.google.guava:guava:${'$'}guavaVersion"
+                compile 'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
+    fun leaveSingleLineDependenciesAlone() {
+        buildFile.appendText("""
+            dependencies {
+                compile 'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("prepareForLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile 'commons-lang:commons-lang:2.+'
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
+    fun leaveDependenciesWithClosuresAlone() {
+        buildFile.appendText("""
+            dependencies {
+                compile('org.springframework.boot:spring-boot-starter-web') {
+                    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-validation'
+                }
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("prepareForLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile('org.springframework.boot:spring-boot-starter-web') {
+                    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-validation'
+                }
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
+    fun leaveMapDependenciesAlone() {
+        buildFile.appendText("""
+            dependencies {
+                compile group: 'commons-lang',
+                    name: 'commons-lang',
+                    version: '2.+'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("prepareForLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile group: 'commons-lang',
+                    name: 'commons-lang',
+                    version: '2.+'
+            }
+        """.trim('\n').trimIndent()))
+    }
+}

--- a/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
@@ -244,4 +244,36 @@ class UpdateLockTaskTest : TestKitTest() {
             }
         """.trim('\n').trimIndent()))
     }
+
+    @Test
+    fun ignoredBlocksAreNotLocked() {
+        buildFile.appendText("""
+            dependencies {
+                compile 'com.google.guava:guava:18.+'
+                nebulaDependencyLock.ignore {
+                    compile module("com.jcraft:jsch.agentproxy:0.0.9") {
+                        ['jsch', 'sshagent', 'usocket-jna', 'usocket-nc'].each {
+                            dependency "com.jcraft:jsch.agentproxy.${'$'}{it}:0.0.9"
+                        }
+                    }
+                }
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("updateLocks")
+
+        val readText = buildFile.readText()
+        assertTrue(readText.contains("""
+            dependencies {
+                compile 'com.google.guava:guava:18.+' lock '18.0'
+                nebulaDependencyLock.ignore {
+                    compile module("com.jcraft:jsch.agentproxy:0.0.9") {
+                        ['jsch', 'sshagent', 'usocket-jna', 'usocket-nc'].each {
+                            dependency "com.jcraft:jsch.agentproxy.${'$'}{it}:0.0.9"
+                        }
+                    }
+                }
+            }
+        """.trim('\n').trimIndent()))
+    }
 }

--- a/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
@@ -191,4 +191,37 @@ class UpdateLockTaskTest : TestKitTest() {
             }
         """.trim('\n').trimIndent()))
     }
+
+    @Test
+    fun lockFromBom() {
+        buildFile.writeText("""
+            plugins {
+                id 'io.spring.dependency-management' version '0.5.7.RELEASE'
+                id 'java'
+                id 'nebula.lock-experimental'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencyManagement {
+                imports {
+                    mavenBom "org.springframework.cloud:spring-cloud-netflix:1.1.2.RELEASE"
+                }
+            }
+
+            dependencies {
+                compile 'org.springframework.cloud:spring-cloud-starter-feign'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("updateLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile 'org.springframework.cloud:spring-cloud-starter-feign' lock '1.1.2.RELEASE'
+            }
+        """.trim('\n').trimIndent()))
+    }
 }

--- a/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
@@ -116,6 +116,26 @@ class UpdateLockTaskTest : TestKitTest() {
     }
 
     @Test
+    fun dependenciesWithClosure() {
+        buildFile.appendText("""
+            dependencies {
+                compile('com.google.guava:guava:18.+') {
+                    changing = true
+                }
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("updateLocks")
+        assertTrue(buildFile.readText().contains("""
+            dependencies {
+                compile('com.google.guava:guava:18.+') {
+                    changing = true
+                } lock '18.0'
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
     fun lockRootProjectDependencies() {
         addSubproject("sub", "plugins { id 'nebula.lock-experimental' }")
 

--- a/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
+++ b/src/test/kotlin/com/netflix/nebula/lock/UpdateLockTaskTest.kt
@@ -52,8 +52,6 @@ class UpdateLockTaskTest : TestKitTest() {
 
         runTasksSuccessfully("updateLocks")
 
-        println(buildFile.readText())
-
         assertTrue(buildFile.readText().contains("""
             dependencies {
                 compile 'com.google.guava:guava:18.+' lock '18.0'
@@ -136,6 +134,59 @@ class UpdateLockTaskTest : TestKitTest() {
         assertTrue(buildFile.readText().contains("""
                 dependencies {
                     compile 'com.google.guava:guava:18.+' lock '18.0'
+                }
+            }
+        """.trim('\n').trimIndent()))
+    }
+
+    @Test
+    fun lockDynamicForces() {
+        buildFile.appendText("""
+            configurations.all {
+                resolutionStrategy {
+                    force 'com.google.guava:guava:16.+'
+                }
+            }
+
+            configurations.compile {
+                resolutionStrategy {
+                    force 'com.google.guava:guava:17.+'
+                }
+            }
+
+            configurations {
+                testCompile {
+                    resolutionStrategy {
+                        force 'com.google.guava:guava:14.+'
+                    }
+                }
+            }
+
+            dependencies {
+                compile 'com.google.guava:guava:latest.release'
+            }
+        """.trim('\n').trimIndent())
+
+        runTasksSuccessfully("updateLocks")
+
+        assertTrue(buildFile.readText().contains("""
+            configurations.all {
+                resolutionStrategy {
+                    force 'com.google.guava:guava:16.+' lock '17.0'
+                }
+            }
+
+            configurations.compile {
+                resolutionStrategy {
+                    force 'com.google.guava:guava:17.+' lock '17.0'
+                }
+            }
+
+            configurations {
+                testCompile {
+                    resolutionStrategy {
+                        force 'com.google.guava:guava:14.+' lock '14.0.1'
+                    }
                 }
             }
         """.trim('\n').trimIndent()))


### PR DESCRIPTION
- `force` in `resolutionStrategy` can now be locked
- dependencies without versions (depending on recommendations from a BOM) can now be locked
- `nebulaDependencyLock.ignore { ... }` will cause the dependency lock to ignore anything in the closure
- `updateLocks` task is now two phases:
  - Convert dependencies in unlockable formats to lockable formats (`compile 'a', 'b'` becomes two lines)
  - Append `lock '<version>'` to the end of the unignored dependencies
